### PR TITLE
specify Net::ZooKeeper version in dependencies

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module App::Switchman
 
+1.07 2014-12-08
+    * specify minimal good version of Net::ZooKeeper in dependencies
+
 1.06 2014-11-24
     * fixed bug in wait_in_queue for the case when the node was removed during processing
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = switchman
-version = 1.06
+version = 1.07
 author = Oleg Komarov <komarov@cpan.org>
 copyright_holder = Yandex LLC
 copyright_year = 2014
@@ -17,6 +17,7 @@ exclude_match = config
 [Prereqs]
 Log::Dispatch = 2.35
 Moo = 1.002000
+Net::Zookeeper = 0.36
 Net::ZooKeeper::Lock = 0.03
 
 [MetaResources]

--- a/lib/App/Switchman.pm
+++ b/lib/App/Switchman.pm
@@ -1,6 +1,6 @@
 package App::Switchman;
 
-our $VERSION = '1.06';
+our $VERSION = '1.07';
 
 =head1 NAME
 


### PR DESCRIPTION
Предыдущие версии (например 0.35) имеют несколько неприятных в эксплуатации багов:
- [ZOOKEEPER-1380](https://issues.apache.org/jira/browse/ZOOKEEPER-1380) - вызывает Segmentation fault самого switchman'а при исключении хоста из  группы в zookeeper'е (на том хосте, который исключили)
  
  ```
  (gdb) run
  Starting program: /usr/bin/perl /usr/bin/switchman -c /home/ppalex/tmp/switchman.conf -g test --lockname lockname --lease FQDN_mem=1000:MEMMB -- /home/ppalex/sleep.pl
  [Thread debugging using libthread_db enabled]
  Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
  [New Thread 0x7ffff38b7700 (LWP 22308)]
  [New Thread 0x7ffff30b6700 (LWP 22309)]
  2014-12-08 18:19:37     [22310] Executing </home/ppalex/sleep.pl>
  let's sleep
  2014-12-08 18:20:03     [22305] Group <test> is not serviced by the current host anymore
  [Thread 0x7ffff38b7700 (LWP 22308) exited]
  [Thread 0x7ffff30b6700 (LWP 22309) exited]
  
  Program received signal SIGSEGV, Segmentation fault.
  0x00007ffff4b2586a in _zk_release_watch (watch=0x155d9e8, list=1, my_perl=<optimized out>) at ZooKeeper.xs:257
  257     ZooKeeper.xs: No such file or directory.
  (gdb) bt
  #0  0x00007ffff4b2586a in _zk_release_watch (watch=0x155d9e8, list=1, my_perl=<optimized out>) at ZooKeeper.xs:257
  #1  0x00007ffff4b25abd in _zk_release_watches (final=1, my_perl=<optimized out>, first_watch=<optimized out>) at ZooKeeper.xs:286
  #2  0x00007ffff4b25bea in XS_Net__ZooKeeper_DESTROY (my_perl=0xa80010, cv=<optimized out>) at ZooKeeper.xs:887
  #3  0x00000000005a693c in Perl_pp_entersub (my_perl=0xa80010) at pp_hot.c:3046
  #4  0x0000000000451eed in Perl_call_sv (my_perl=0xa80010, sv=0x1037d00, flags=45) at perl.c:2647
  #5  0x00000000005ed5d6 in S_curse (my_perl=0xa80010, sv=0x14b7f48, check_refcnt=1 '\001') at sv.c:6342
  #6  0x00000000005eb550 in Perl_sv_clear (my_perl=0xa80010, orig_sv=0x14b7f48) at sv.c:6073
  #7  0x00000000005ee21e in Perl_sv_free2 (my_perl=0xa80010, sv=0x14b7f48) at sv.c:6474
  #8  0x00000000005ab2c5 in do_clean_objs (my_perl=0xa80010, ref=0x14b7f60) at sv.c:478
  #9  0x00000000005aac42 in S_visit (my_perl=0xa80010, f=0x5aacf7 <do_clean_objs>, flags=2048, mask=2048) at sv.c:420
  #10 0x00000000005ac340 in Perl_sv_clean_objs (my_perl=0xa80010) at sv.c:579
  #11 0x0000000000449303 in perl_destruct (my_perl=0xa80010) at perl.c:775
  #12 0x0000000000419f86 in main (argc=15, argv=0x7fffffffdcd8, env=0x7fffffffdd58) at perlmain.c:131
  (gdb) 
  ```
- [ZOOKEEPER-1062](https://issues.apache.org/jira/browse/ZOOKEEPER-1062)

Версия 0.36 собрана с исправленным ZooKeeper.xs и этим проблемам не подвержена, поэтому выглядит разумным изменить у switchman'а зависимость от Net::Zookeeper с безусловной на версию >=0.36.
