### PR TITLE
More reliable resource waiting timeout

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl module App::Switchman
 
+1.12 2015-09-10
+    * changed handling of ALARM - use unsafe signals
+    * improved debug logging
+    * switchman leaves queues before locking
+    * wait_in_queue optimization - watch not for the head of queue, but for the neighbour
+
 1.11 2015-07-01
     * fix typo in dependencies
 

--- a/README.md
+++ b/README.md
@@ -223,3 +223,4 @@ the same terms as the Perl 5 programming language system itself.
     Gennadiy Filatov
     Oleg Komarov <komarov@cpan.org>
     Pavel Selivanov
+    Sergey Zhuravlev

--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ Log::Dispatch = 2.35
 Moo = 1.002000
 Net::ZooKeeper = 0.38
 Net::ZooKeeper::Lock = 0.03
+Sys::SigAction = 0.21
 
 [MetaResources]
 homepage = https://github.com/komarov/switchman


### PR DESCRIPTION
Привет.

Столкнулись с подвисаниями процессов, стоящих в голове очереди. Казалось бы, должен срабатывать resource_wait_timeout, но процесс висит внутри libzookeeper_mt2.so, поэтому "безопасные" сигналы перла не работают.

Заменил сигналы на небезопасные, плюс несколько улучшений рядом.

