### PR TITLE
Fix bug with empty fqdn on ipv6only hosts

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module App::Switchman
 
+1.16 2016-10-26
+    * fixed fqdn determination on ipv6-only hosts
+
 1.15 2016-05-28
     * https://github.com/komarov/switchman/pull/10 zk_connect as a public method
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ debuild
 
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012-2015 by Yandex LLC.
+This software is copyright (c) 2012-2016 by Yandex LLC.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/bin/check_switchman_groups
+++ b/bin/check_switchman_groups
@@ -49,7 +49,7 @@ __END__
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012-2015 by Yandex LLC.
+This software is copyright (c) 2012-2016 by Yandex LLC.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/bin/check_switchman_hosts
+++ b/bin/check_switchman_hosts
@@ -48,7 +48,7 @@ __END__
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012-2015 by Yandex LLC.
+This software is copyright (c) 2012-2016 by Yandex LLC.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/bin/switchman
+++ b/bin/switchman
@@ -225,7 +225,7 @@ which is critical in case of network split.
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012-2015 by Yandex LLC.
+This software is copyright (c) 2012-2016 by Yandex LLC.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = switchman
-version = 1.15
+version = 1.16
 author = Oleg Komarov <komarov@cpan.org>
 copyright_holder = Yandex LLC
 copyright_year = 2016

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name = switchman
 version = 1.15
 author = Oleg Komarov <komarov@cpan.org>
 copyright_holder = Yandex LLC
-copyright_year = 2015
+copyright_year = 2016
 license = Perl_5
 main_module = bin/switchman
 

--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,7 @@ exclude_match = config
 [Prereqs]
 Log::Dispatch = 2.35
 Moo = 1.002000
+Net::Domain = 2.20
 Net::ZooKeeper = 0.38
 Net::ZooKeeper::Lock = 0.03
 Sys::SigAction = 0.20

--- a/lib/App/Switchman.pm
+++ b/lib/App/Switchman.pm
@@ -1,6 +1,6 @@
 package App::Switchman;
 
-our $VERSION = '1.15';
+our $VERSION = '1.16';
 
 =head1 NAME
 

--- a/lib/App/Switchman.pm
+++ b/lib/App/Switchman.pm
@@ -23,13 +23,13 @@ use List::MoreUtils qw(part uniq);
 use List::Util qw(max);
 use Log::Dispatch;
 use Moo;
+use Net::Domain qw(hostfqdn);
 use Net::ZooKeeper qw(:acls :errors :events :node_flags);
 use Net::ZooKeeper::Semaphore;
 use Pod::Usage;
 use POSIX qw(strftime);
 use Scalar::Util qw(blessed);
 use Sys::CPU;
-use Sys::Hostname::FQDN qw(fqdn);
 use Sys::SigAction qw(set_sig_handler);
 
 
@@ -298,7 +298,7 @@ sub is_group_serviced
 
     $self->load_prefix_data;
     my $hosts = $self->get_group_hosts($self->prefix_data->{groups}, $self->group);
-    my $fqdn = fqdn();
+    my $fqdn = hostfqdn();
     my $is_serviced = grep {$fqdn eq $_} @$hosts;
     return $is_serviced;
 }
@@ -737,7 +737,7 @@ sub _get_and_check_config
 
 sub _node_data
 {
-    return fqdn()." $$";
+    return hostfqdn()." $$";
 }
 
 
@@ -748,7 +748,7 @@ sub _process_resource_macro
     my %mem_info = Linux::MemInfo::get_mem_info();
     my %expand = (
         CPU => Sys::CPU::cpu_count(),
-        FQDN => fqdn(),
+        FQDN => hostfqdn(),
         MEMMB => int($mem_info{MemTotal} / 1024),
     );
     my $re = join '|', keys %expand;

--- a/lib/App/Switchman.pm
+++ b/lib/App/Switchman.pm
@@ -778,7 +778,7 @@ __END__
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012-2015 by Yandex LLC.
+This software is copyright (c) 2012-2016 by Yandex LLC.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.


### PR DESCRIPTION
На ipv6-only хостах `fqdn()` ничего не возвращает, что не позволяет работать с группами

```
perl -MNet::Domain=hostfqdn -MSys::Hostname::FQDN=fqdn -Mwarnings -Mstrict -MDDP -le 'my %test = (new => hostfqdn(), old => fqdn()); p %test'
Odd number of elements in hash assignment at -e line 1.
{
    new   "somehost.yandex.ru",
    old   undef
}
```
